### PR TITLE
Don't attempt to load non-elisp files in `psession--restore-objects-from-directory`

### DIFF
--- a/psession.el
+++ b/psession.el
@@ -104,7 +104,7 @@ That may not work with Emacs versions <=23.1 for hash tables."
 
 (cl-defun psession--restore-objects-from-directory
     (&optional (dir psession-elisp-objects-default-directory))
-  (let ((file-list (cddr (directory-files dir t))))
+  (let ((file-list (cddr (directory-files dir t "\\.elc?\\'"))))
     (cl-loop for file in file-list do (and file (load file)))))
 
 (defun psession--dump-object-no-properties (object file)


### PR DESCRIPTION
I encountered an error during startup relating to `psession--restore-objects-from-directory` attempting to load a directory:

```lisp
(file-error "Cannot open load file" "Is a directory" "/Users/jguenther/.emacs.d/elisp-objects/..")
```

Without the MATCH arg, `directory-files` returns all files in a directory (including sub-directories and the `.` and `..` directories). This change filters the return value of `directory-files` to exclude non-elisp files.
